### PR TITLE
dump signature in text format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.o
+Makefile
+autom4te.cache/
+config.log
+config.status
+configure
+libmash.a
+mash

--- a/Makefile.in
+++ b/Makefile.in
@@ -17,6 +17,7 @@ SOURCES=\
 	src/mash/CommandDistance.cpp \
 	src/mash/CommandFind.cpp \
 	src/mash/CommandInfo.cpp \
+	src/mash/CommandDump.cpp \
 	src/mash/CommandPaste.cpp \
 	src/mash/CommandSketch.cpp \
 	src/mash/CommandList.cpp \

--- a/src/mash/CommandDump.cpp
+++ b/src/mash/CommandDump.cpp
@@ -1,0 +1,78 @@
+// Copyright © 2015, Battelle National Biodefense Institute (BNBI);
+// all rights reserved. Authored by: Brian Ondov, Todd Treangen,
+// Sergey Koren, and Adam Phillippy
+//
+// See the LICENSE.txt file included with this software for license information.
+
+#include "CommandDump.h"
+#include "Sketch.h"
+#include <iostream>
+
+#include <fstream>
+#include <sstream>
+using namespace::std;
+
+CommandDump::CommandDump()
+: Command()
+{
+    name = "dump";
+    summary = "Save sketch information into a text format.";
+    description = "Save sketch information into a text format.";
+    argumentString = "<sketch> <dumpfile>";
+
+    useOption("help");
+}
+
+int CommandDump::run() const
+{
+    if ( arguments.size() != 2 || options.at("help").active )
+    {
+        print();
+        return 0;
+    }
+
+    const string & file = arguments[0];
+    const string & dumpfile = arguments[1];
+
+    if ( ! hasSuffix(file, suffixSketch) )
+    {
+        cerr << "ERROR: The file \"" << file << "\" does not look like a sketch." << endl;
+        return 1;
+    }
+
+    Sketch sketch;
+    Sketch::Parameters params;
+    params.parallelism = 1;
+
+    vector<string> sketchFiles;
+    sketchFiles.push_back(file);
+    sketch.initFromFiles(sketchFiles, params);
+
+    string alphabet;
+    sketch.getAlphabetAsString(alphabet);
+
+    cout << "Header:" << endl;
+    cout << "  K-mer size:                    " << sketch.getKmerSize() << " (" << (sketch.getUse64() ? "64" : "32") << "-bit hashes)" << endl;
+    cout << "  Alphabet:                      " << alphabet << (sketch.getNoncanonical() ? "" : " (canonical)") << (sketch.getPreserveCase() ? " (case-sensitive)" : "") << endl;
+    cout << "  Target min-hashes per sketch:  " << sketch.getMinHashesPerWindow() << endl;
+
+    std::string hashfn = (sketch.getUse64() ? "murmur64" : "murmur32");
+
+    ofstream outfile(dumpfile, ios::out);
+    for ( uint64_t i = 0; i < sketch.getReferenceCount(); i++ )
+    {
+        const Sketch::Reference & ref = sketch.getReference(i);
+
+        outfile << hashfn << "," << seed << "," << sketch.getKmerSize()
+                << "," << ref.name << ",";
+        for ( int i = 0 ; i < ref.hashesSorted.size(); i ++) {
+            outfile << ref.hashesSorted.at(i).hash64 << " ";
+        }
+        outfile << "\n";
+    }
+    outfile.close();
+
+    cout << "Dumped " << sketch.getReferenceCount() << " sketches to '"
+         << dumpfile << "'" << endl;
+    return 0;
+}

--- a/src/mash/CommandDump.h
+++ b/src/mash/CommandDump.h
@@ -1,0 +1,22 @@
+// Copyright © 2015, Battelle National Biodefense Institute (BNBI);
+// all rights reserved. Authored by: Brian Ondov, Todd Treangen,
+// Sergey Koren, and Adam Phillippy
+//
+// See the LICENSE.txt file included with this software for license information.
+
+#ifndef INCLUDED_CommandDump
+#define INCLUDED_CommandDump
+
+#include "Command.h"
+#include "Sketch.h"
+
+class CommandDump : public Command
+{
+public:
+
+    CommandDump();
+
+    int run() const; // override
+};
+
+#endif

--- a/src/mash/CommandInfo.cpp
+++ b/src/mash/CommandInfo.cpp
@@ -8,8 +8,6 @@
 #include "Sketch.h"
 #include <iostream>
 
-#include <fstream>
-#include <sstream>
 using namespace::std;
 
 CommandInfo::CommandInfo()
@@ -125,16 +123,6 @@ int CommandInfo::run() const
 				columns[2].push_back(ref.name);
 				columns[3].push_back(ref.comment);
 			}
-
-
-            ofstream outfile("xxx", ios::out);
-            outfile << "murmur64," << seed << "," << sketch.getKmerSize()
-                    << "," << ref.name << ",";
-            for ( int i = 0 ; i < ref.hashesSorted.size(); i ++) {
-                outfile << ref.hashesSorted.at(i).hash64 << " ";
-            }
-            outfile << "\n";
-            outfile.close();
         }
         
         if ( ! tabular )

--- a/src/mash/CommandInfo.cpp
+++ b/src/mash/CommandInfo.cpp
@@ -8,6 +8,8 @@
 #include "Sketch.h"
 #include <iostream>
 
+#include <fstream>
+#include <sstream>
 using namespace::std;
 
 CommandInfo::CommandInfo()
@@ -123,6 +125,16 @@ int CommandInfo::run() const
 				columns[2].push_back(ref.name);
 				columns[3].push_back(ref.comment);
 			}
+
+
+            ofstream outfile("xxx", ios::out);
+            outfile << "murmur64," << seed << "," << sketch.getKmerSize()
+                    << "," << ref.name << ",";
+            for ( int i = 0 ; i < ref.hashesSorted.size(); i ++) {
+                outfile << ref.hashesSorted.at(i).hash64 << " ";
+            }
+            outfile << "\n";
+            outfile.close();
         }
         
         if ( ! tabular )

--- a/src/mash/mash.cpp
+++ b/src/mash/mash.cpp
@@ -11,6 +11,7 @@
 #include "CommandDistance.h"
 #include "CommandContain.h"
 #include "CommandInfo.h"
+#include "CommandDump.h"
 #include "CommandPaste.h"
 
 using namespace::std;
@@ -31,6 +32,7 @@ int main(int argc, const char ** argv)
     commandList.addCommand(new CommandInfo());
     commandList.addCommand(new CommandPaste());
     commandList.addCommand(new CommandBounds());
+    commandList.addCommand(new CommandDump());
     
     return commandList.run(argc, argv);
 }


### PR DESCRIPTION
Prototype implementation of text dump format for MinHash sketches created by mash; see https://github.com/marbl/Mash/issues/27.
